### PR TITLE
USE V-0.1.9 (or lower) OF PYTORCH, AND NOT V-0.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # pytorch-a3c
 
+NEED TO USE V-0.1.9 (or lower) OF PYTORCH, AND NOT V-0.1.10 BECAUSE OF THIS ISSUE:
+https://discuss.pytorch.org/t/problem-on-variable-grad-data/957/7
+
 This is a PyTorch implementation of Asynchronous Advantage Actor Critic (A3C) from ["Asynchronous Methods for Deep Reinforcement Learning"](https://arxiv.org/pdf/1602.01783v1.pdf).
 
 This implementation is inspired by [Universe Starter Agent](https://github.com/openai/universe-starter-agent).


### PR DESCRIPTION
NEED TO USE V-0.1.9 (or lower) OF PYTORCH, AND NOT V-0.1.10 BECAUSE OF THIS ISSUE:
https://discuss.pytorch.org/t/problem-on-variable-grad-data/957/7

Although I'm not positive. Maybe it somehow does still work with V-0.1.10 even though you can't manually reinitialize the gradient unless you use D_Kay's init hack.