### PR TITLE
SELU seems to converge faster than ELU

### DIFF
--- a/model.py
+++ b/model.py
@@ -31,15 +31,6 @@ def weights_init(m):
         m.weight.data.uniform_(-w_bound, w_bound)
         m.bias.data.fill_(0)
 
-#https://github.com/pytorch/pytorch/issues/1768
-class SELU(nn.ELU):
-    def __init__(self):
-        super(SELU, self).__init__()
-        self.alpha = 1.6732632423543772848170429916717
-        self.scale = 1.0507009873554804934193349852946
-
-    def forward(self, input):
-        return self.scale * F.elu(input, self.alpha, self.inplace)
 
 class ActorCritic(torch.nn.Module):
 
@@ -48,8 +39,7 @@ class ActorCritic(torch.nn.Module):
         self.conv1 = nn.Conv2d(num_inputs, 32, 3, stride=2, padding=1)
         self.conv2 = nn.Conv2d(32, 32, 3, stride=2, padding=1)
         self.conv3 = nn.Conv2d(32, 32, 3, stride=2, padding=1)
-        self.conv4 = nn.Conv2d(32, 32, 3, stride=2, padding=1)        
-        self.selu = SELU()
+        self.conv4 = nn.Conv2d(32, 32, 3, stride=2, padding=1)
 
         self.lstm = nn.LSTMCell(32 * 3 * 3, 256)
 
@@ -72,10 +62,10 @@ class ActorCritic(torch.nn.Module):
 
     def forward(self, inputs):
         inputs, (hx, cx) = inputs
-        x = self.selu(self.conv1(inputs))
-        x = self.selu(self.conv2(x))
-        x = self.selu(self.conv3(x))
-        x = self.selu(self.conv4(x))
+        x = F.selu(self.conv1(inputs))
+        x = F.selu(self.conv2(x))
+        x = F.selu(self.conv3(x))
+        x = F.selu(self.conv4(x))
 
         x = x.view(-1, 32 * 3 * 3)
         hx, cx = self.lstm(x, (hx, cx))

--- a/model.py
+++ b/model.py
@@ -31,6 +31,15 @@ def weights_init(m):
         m.weight.data.uniform_(-w_bound, w_bound)
         m.bias.data.fill_(0)
 
+#https://github.com/pytorch/pytorch/issues/1768
+class SELU(nn.ELU):
+    def __init__(self):
+        super(SELU, self).__init__()
+        self.alpha = 1.6732632423543772848170429916717
+        self.scale = 1.0507009873554804934193349852946
+
+    def forward(self, input):
+        return self.scale * F.elu(input, self.alpha, self.inplace)
 
 class ActorCritic(torch.nn.Module):
 
@@ -39,7 +48,8 @@ class ActorCritic(torch.nn.Module):
         self.conv1 = nn.Conv2d(num_inputs, 32, 3, stride=2, padding=1)
         self.conv2 = nn.Conv2d(32, 32, 3, stride=2, padding=1)
         self.conv3 = nn.Conv2d(32, 32, 3, stride=2, padding=1)
-        self.conv4 = nn.Conv2d(32, 32, 3, stride=2, padding=1)
+        self.conv4 = nn.Conv2d(32, 32, 3, stride=2, padding=1)        
+        self.selu = SELU()
 
         self.lstm = nn.LSTMCell(32 * 3 * 3, 256)
 
@@ -62,10 +72,10 @@ class ActorCritic(torch.nn.Module):
 
     def forward(self, inputs):
         inputs, (hx, cx) = inputs
-        x = F.elu(self.conv1(inputs))
-        x = F.elu(self.conv2(x))
-        x = F.elu(self.conv3(x))
-        x = F.elu(self.conv4(x))
+        x = self.selu(self.conv1(inputs))
+        x = self.selu(self.conv2(x))
+        x = self.selu(self.conv3(x))
+        x = self.selu(self.conv4(x))
 
         x = x.view(-1, 32 * 3 * 3)
         hx, cx = self.lstm(x, (hx, cx))


### PR DESCRIPTION
Eventually would want to swap with SELU that's built into pytorch once it merged.

Here's a run with SELU activations:
OMP_NUM_THREADS=1 python3 main.py --env-name "PongDeterministic-v4" --num-processes 7
Time 00h 00m 07s, episode reward -21.0, episode length 764
Time 00h 01m 08s, episode reward -2.0, episode length 107
Time 00h 02m 09s, episode reward -2.0, episode length 103
Time 00h 03m 18s, episode reward -21.0, episode length 764
Time 00h 04m 26s, episode reward -21.0, episode length 764
Time 00h 05m 34s, episode reward -21.0, episode length 764
Time 00h 06m 43s, episode reward -21.0, episode length 764
Time 00h 07m 52s, episode reward -21.0, episode length 764
Time 00h 08m 54s, episode reward -4.0, episode length 190
Time 00h 10m 03s, episode reward -21.0, episode length 764
Time 00h 11m 12s, episode reward -21.0, episode length 764
Time 00h 12m 21s, episode reward -21.0, episode length 764
Time 00h 13m 42s, episode reward -18.0, episode length 2082
Time 00h 15m 09s, episode reward -19.0, episode length 2427
Time 00h 16m 31s, episode reward -20.0, episode length 1879
Time 00h 17m 32s, episode reward -3.0, episode length 160
Time 00h 18m 52s, episode reward -20.0, episode length 1621
Time 00h 20m 14s, episode reward -21.0, episode length 1964
Time 00h 21m 31s, episode reward -21.0, episode length 1488
Time 00h 22m 54s, episode reward -20.0, episode length 2117
Time 00h 24m 21s, episode reward -14.0, episode length 2326
Time 00h 25m 40s, episode reward -20.0, episode length 1768
Time 00h 26m 58s, episode reward -21.0, episode length 1644
Time 00h 28m 31s, episode reward -12.0, episode length 2736
Time 00h 29m 41s, episode reward -20.0, episode length 962
Time 00h 31m 13s, episode reward -11.0, episode length 2700
Time 00h 32m 30s, episode reward -20.0, episode length 1498
Time 00h 34m 03s, episode reward 10.0, episode length 2781
Time 00h 35m 25s, episode reward 19.0, episode length 2130
Time 00h 36m 55s, episode reward -20.0, episode length 2658
Time 00h 38m 20s, episode reward -19.0, episode length 2123
Time 00h 39m 45s, episode reward 18.0, episode length 2356
Time 00h 41m 18s, episode reward 11.0, episode length 2852
Time 00h 42m 42s, episode reward -21.0, episode length 2013
Time 00h 44m 09s, episode reward 18.0, episode length 2505
Time 00h 47m 07s, episode reward 0.0, episode length 10000
Time 00h 48m 28s, episode reward 21.0, episode length 1995
Time 00h 49m 51s, episode reward 20.0, episode length 2008
Time 00h 51m 14s, episode reward 20.0, episode length 2008
Time 00h 52m 37s, episode reward 20.0, episode length 2008
Time 00h 54m 11s, episode reward 12.0, episode length 3246
Time 00h 55m 38s, episode reward 18.0, episode length 2394
Time 00h 57m 03s, episode reward 20.0, episode length 2223
Time 00h 58m 26s, episode reward 20.0, episode length 2008


Here's a run with ELU activations:
OMP_NUM_THREADS=1 python3 main.py --env-name "PongDeterministic-v4" --num-processes 7
Time 00h 00m 07s, episode reward -21.0, episode length 764
Time 00h 01m 08s, episode reward -2.0, episode length 100
Time 00h 02m 09s, episode reward -2.0, episode length 102
Time 00h 03m 10s, episode reward -2.0, episode length 104
Time 00h 04m 11s, episode reward -2.0, episode length 114
Time 00h 05m 12s, episode reward -2.0, episode length 117
Time 00h 06m 13s, episode reward -2.0, episode length 112
Time 00h 07m 14s, episode reward -2.0, episode length 119
Time 00h 08m 23s, episode reward -21.0, episode length 764
Time 00h 09m 25s, episode reward -3.0, episode length 166
Time 00h 10m 32s, episode reward -21.0, episode length 764
Time 00h 11m 42s, episode reward -21.0, episode length 764
Time 00h 12m 50s, episode reward -21.0, episode length 764
Time 00h 13m 58s, episode reward -21.0, episode length 764
Time 00h 15m 07s, episode reward -21.0, episode length 830
Time 00h 16m 15s, episode reward -21.0, episode length 764
Time 00h 17m 23s, episode reward -21.0, episode length 764
Time 00h 18m 32s, episode reward -21.0, episode length 764
Time 00h 19m 40s, episode reward -21.0, episode length 764
Time 00h 20m 58s, episode reward -19.0, episode length 1706
Time 00h 22m 17s, episode reward -19.0, episode length 1696
Time 00h 23m 39s, episode reward -21.0, episode length 1964
Time 00h 25m 01s, episode reward -21.0, episode length 1964
Time 00h 26m 24s, episode reward -16.0, episode length 2144
Time 00h 27m 40s, episode reward -18.0, episode length 1426
Time 00h 29m 04s, episode reward -13.0, episode length 2240
Time 00h 30m 29s, episode reward -21.0, episode length 2466
Time 00h 32m 03s, episode reward -1.0, episode length 3030
Time 00h 33m 24s, episode reward -20.0, episode length 2006
Time 00h 34m 49s, episode reward -13.0, episode length 2365
Time 00h 36m 17s, episode reward -21.0, episode length 2552
Time 00h 37m 43s, episode reward -11.0, episode length 2290
Time 00h 39m 13s, episode reward -19.0, episode length 2723
Time 00h 40m 36s, episode reward -20.0, episode length 2094
Time 00h 42m 12s, episode reward -19.0, episode length 3404
Time 00h 43m 24s, episode reward -19.0, episode length 1089
Time 00h 44m 51s, episode reward -21.0, episode length 2544
Time 00h 46m 19s, episode reward -20.0, episode length 2449
Time 00h 47m 40s, episode reward -21.0, episode length 1993
Time 00h 49m 12s, episode reward -1.0, episode length 2813
Time 00h 50m 43s, episode reward -1.0, episode length 2813
Time 00h 52m 16s, episode reward -1.0, episode length 2813
Time 00h 53m 40s, episode reward 19.0, episode length 2155
Time 00h 55m 01s, episode reward 20.0, episode length 2008
Time 00h 56m 27s, episode reward 13.0, episode length 2542
Time 00h 57m 51s, episode reward 19.0, episode length 2187
Time 00h 59m 16s, episode reward 20.0, episode length 2036
Time 01h 00m 38s, episode reward 15.0, episode length 2167
Time 01h 02m 01s, episode reward 19.0, episode length 2075
Time 01h 03m 24s, episode reward 19.0, episode length 2103
Time 01h 05m 03s, episode reward 2.0, episode length 3434
Time 01h 06m 34s, episode reward 10.0, episode length 2872
Time 01h 08m 11s, episode reward 2.0, episode length 3434
Time 01h 09m 51s, episode reward 1.0, episode length 3592
Time 01h 11m 15s, episode reward 19.0, episode length 2216
Time 01h 12m 23s, episode reward -21.0, episode length 764
Time 01h 13m 44s, episode reward 20.0, episode length 2008
Time 01h 15m 15s, episode reward 9.0, episode length 2848
Time 01h 16m 37s, episode reward 20.0, episode length 2059
Time 01h 18m 00s, episode reward 20.0, episode length 2020
Time 01h 19m 22s, episode reward 20.0, episode length 2008
Time 01h 20m 44s, episode reward 19.0, episode length 2103
Time 01h 22m 07s, episode reward 21.0, episode length 2038
Time 01h 23m 38s, episode reward 11.0, episode length 2714
Time 01h 25m 02s, episode reward 20.0, episode length 2047
Time 01h 26m 24s, episode reward 20.0, episode length 2008