### PR TITLE
changed reshape to moveaxis

### DIFF
--- a/envs.py
+++ b/envs.py
@@ -19,10 +19,10 @@ def _process_frame42(frame):
     # aren't close enough to the pixel boundary.
     frame = cv2.resize(frame, (80, 80))
     frame = cv2.resize(frame, (42, 42))
-    frame = frame.mean(2)
+    frame = frame.mean(2, keepdims=True)
     frame = frame.astype(np.float32)
     frame *= (1.0 / 255.0)
-    frame = np.reshape(frame, [1, 42, 42])
+    frame = np.moveaxis(frame, -1, 0)
     return frame
 
 


### PR DESCRIPTION
The reason for this change is that np.reshape(frame, [C, H, W]) does not work correctly for full color images. The change here gives exactly the same behavior as the old code when used on greyscale images, and also allows for training on full color images by removing the frame.mean() line.